### PR TITLE
add payments services

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -20,14 +20,8 @@ class Payment < ApplicationRecord
   belongs_to :sender, class_name: 'User'
   belongs_to :receiver, class_name: 'User'
 
+  delegate :payment_account, to: :sender, prefix: true
+  delegate :payment_account, to: :receiver, prefix: true
+
   validates :amount, presence: true, numericality: { greater_than: 0, less_than: 1_000 }
-  validate :users_friendship
-
-  private
-
-  def users_friendship
-    return if sender&.friend_with?(receiver)
-
-    errors.add(:base, I18n.t('model.payment.error.users_friendship'))
-  end
 end

--- a/app/services/money_transfer_service.rb
+++ b/app/services/money_transfer_service.rb
@@ -1,0 +1,14 @@
+class MoneyTransferService
+  attr_reader :external_payment_source, :user_payment_account
+
+  def initialize(external_payment_source, user_payment_account)
+    @external_payment_source = external_payment_source
+    @user_payment_account = user_payment_account
+  end
+
+  def transfer(amount)
+    external_payment_source.try(:send_money​, amount)
+    user_payment_account.try(:add_to_balance​, amount)
+    true
+  end
+end

--- a/app/services/payment_account_service.rb
+++ b/app/services/payment_account_service.rb
@@ -1,0 +1,29 @@
+class PaymentAccountService
+  attr_reader :account
+
+  def initialize(account)
+    @account = account
+  end
+
+  def increase!(amount)
+    return unless amount.positive?
+
+    balance = account.balance
+    account.update!(balance: balance + amount)
+  end
+
+  def decrease!(amount)
+    return unless amount.positive?
+
+    balance = account.balance
+
+    if amount > balance
+      MoneyTransferService.new(Object.new, account).transfer(amount - balance)
+      new_balance = 0
+    else
+      new_balance = balance - amount
+    end
+
+    account.update!(balance: new_balance)
+  end
+end

--- a/app/services/payment_service.rb
+++ b/app/services/payment_service.rb
@@ -1,0 +1,37 @@
+class PaymentService
+  attr_reader :sender, :receiver, :amount, :description
+
+  def initialize(sender, receiver, amount, description)
+    @sender = sender
+    @receiver = receiver
+    @amount = amount
+    @description = description
+  end
+
+  def create!
+    validate_friendship!
+
+    ActiveRecord::Base.transaction do
+      payment = create_payment
+      PaymentAccountService.new(payment.sender_payment_account).decrease!(payment.amount)
+      PaymentAccountService.new(payment.receiver_payment_account).increase!(payment.amount)
+    end
+  end
+
+  private
+
+  def validate_friendship!
+    return if sender.friend_with?(receiver)
+
+    raise Exceptions::NotFriend, I18n.t('model.payment.error.users_friendship')
+  end
+
+  def create_payment
+    Payment.create!(
+      sender: sender,
+      receiver: receiver,
+      amount: amount,
+      description: description
+    )
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,7 @@ module VenmoApi
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.autoload_paths += %W[#{config.root}/lib]
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -1,0 +1,3 @@
+module Exceptions
+  class NotFriend < StandardError; end
+end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -29,32 +29,5 @@ describe Payment, type: :model do
     it do
       is_expected.to validate_numericality_of(:amount).is_greater_than(0).is_less_than(1_000)
     end
-
-    describe '#users_friendship' do
-      let(:sender) { create(:user) }
-      let(:receiver) { create(:user) }
-
-      subject { build(:payment, sender: sender, receiver: receiver) }
-
-      context 'when sender and receiver are not friends' do
-        it 'is not valid' do
-          expect(subject).not_to be_valid
-        end
-
-        it 'adds users_friendship error message' do
-          subject.valid?
-          error_message = I18n.t('model.payment.error.users_friendship')
-          expect(subject.errors.messages[:base]).to include(error_message)
-        end
-      end
-
-      context 'when sender and receiver are friends' do
-        let!(:friendship) { create(:friendship, user_a: sender, user_b: receiver) }
-
-        it 'is valid' do
-          expect(subject).to be_valid
-        end
-      end
-    end
   end
 end

--- a/spec/services/payment_account_service_spec copy.rb
+++ b/spec/services/payment_account_service_spec copy.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+describe PaymentAccountService, type: :service do
+  describe '#increase!' do
+    let(:user) { create(:user) }
+    before do
+      user.payment_account.update!(balance: 10)
+    end
+
+    subject { described_class.new(user.payment_account).increase!(amount) }
+
+    context 'when amount is positive' do
+      let(:amount) { 20 }
+
+      it 'increases account balance 10 dolars' do
+        expect { subject }.to change(user.payment_account, :balance).from(10).to(30)
+      end
+    end
+
+    context 'when amount is negative' do
+      let(:amount) { -20 }
+
+      it 'does not change balance' do
+        expect { subject }.not_to change(user.payment_account, :balance)
+      end
+    end
+  end
+
+  describe '#decrease!' do
+    let(:user) { create(:user) }
+
+    before do
+      user.payment_account.update!(balance: initial_balance)
+    end
+
+    subject { described_class.new(user.payment_account).decrease!(amount) }
+
+    context 'when amount is positive' do
+      let(:amount) { 10 }
+
+      context 'when amount is smaller than balance' do
+        let(:initial_balance) { 20 }
+
+        it 'decreases account balance 10 dolars' do
+          expect { subject }.to change(user.payment_account, :balance).from(20).to(10)
+        end
+
+        it 'does not call MoneyTransferService' do
+          expect_any_instance_of(MoneyTransferService).not_to receive(:transfer)
+          subject
+        end
+      end
+
+      context 'when amount is greater than balance' do
+        let(:initial_balance) { 6 }
+
+        it 'decreases account balance to 0 dolars' do
+          expect { subject }.to change(user.payment_account, :balance).from(6).to(0)
+        end
+
+        it 'calls MoneyTransferService' do
+          expect_any_instance_of(MoneyTransferService).to receive(:transfer).with(4)
+          subject
+        end
+      end
+    end
+
+    context 'when amount is negative' do
+      let(:amount) { -20 }
+      let(:initial_balance) { 40 }
+
+      it 'does not change balance' do
+        expect { subject }.not_to change(user.payment_account, :balance)
+      end
+    end
+  end
+end

--- a/spec/services/payment_service_spec.rb
+++ b/spec/services/payment_service_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+describe PaymentService, type: :service do
+  describe '#create!' do
+    let(:sender) { create(:user) }
+    let(:receiver) { create(:user) }
+    let(:sender_initial_balance) { 50 }
+    let(:receiver_initial_balance) { 50 }
+    let(:description) { 'description' }
+    let(:amount) { 10 }
+
+    before do
+      sender.payment_account.update!(balance: sender_initial_balance)
+      receiver.payment_account.update!(balance: receiver_initial_balance)
+    end
+
+    subject { described_class.new(sender, receiver, amount, description).create! }
+
+    context 'when sender and receiver are not friends' do
+      it 'raises a NotFriend error' do
+        expect { subject }.to raise_exception(Exceptions::NotFriend).and(
+          change(Payment, :count).by(0)
+        )
+      end
+    end
+
+    context 'when sender and receiver are friends' do
+      let!(:friendship) { create(:friendship, user_a: sender, user_b: receiver) }
+
+      it 'does not raise a argument error' do
+        expect { subject }.not_to raise_exception(Exceptions::NotFriend)
+      end
+
+      it 'decreases sender balance' do
+        expect { subject }.to change(sender, :payment_account_balance).from(50).to(40)
+      end
+
+      it 'increases recevier balance' do
+        expect { subject }.to change(receiver, :payment_account_balance).from(50).to(60)
+      end
+
+      it 'creates Payment' do
+        expect { subject }.to change(Payment, :count).by(1)
+      end
+
+      it 'creates Payment with correct attributes' do
+        subject
+        expect(Payment.last.sender).to eq(sender)
+        expect(Payment.last.receiver).to eq(receiver)
+        expect(Payment.last.amount).to eq(amount)
+        expect(Payment.last.description).to eq(description)
+      end
+
+      context 'when amount is negative' do
+        let(:amount) { -10 }
+
+        it 'raises a RecordInvalid error' do
+          expect { subject }.to raise_exception(ActiveRecord::RecordInvalid).and(
+            change(Payment, :count).by(0)
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In this PR:

* Create `PaymentService` to handle payment creations
* Create `PaymentAccountService` to handle accounts debits and credits
* Create `MoneyTransferService` to mock services with external source
* Remove Payment users_friendship validation in model
* Tests

Note
Payment users_friendship was deleted from model because a payment can be done while sender and recevier are friends , and after the payment the could become not friends, and that does not make the payment invalid